### PR TITLE
Angular template files fail when using `width: {{myWidth}}`

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,10 +56,24 @@ module.exports = function(plugins, options) {
             }
 
             if (node.attrs && node.attrs.style) {
-                promise = css.process(node.attrs.style, options)
-                    .then(function(result) {
-                        node.attrs.style = result.css;
+                promise = new Promise(function(resolve, reject) {
+
+                    // First create a postcss promise
+                    var thisPromise = css.process(node.attrs.style, options)
+                        .then(function(result) {
+                            node.attrs.style = result.css;
+                        });
+                        
+                    thisPromise.then(function(res) {
+                        resolve(res);
+                    }, function(error) {
+                       if (error.name === 'CssSyntaxError' && error.reason === 'Unknown word') {
+                            resolve();
+                       } else {
+                            reject(error);
+                       }
                     });
+                });
 
                 promises.push(promise);
             }
@@ -69,6 +83,8 @@ module.exports = function(plugins, options) {
 
         return Promise.all(promises).then(function() {
             return tree;
+        }, function(errors) {
+            throw new Error(errors);
         });
     };
 };

--- a/test/test.js
+++ b/test/test.js
@@ -54,4 +54,11 @@ describe('use postcss', function() {
         var expected = 'text <style>\n.test { color: red; }</style>';
         test(html, expected, {}, done);
     });
+
+    // Angular edge cases
+    it('style attrs angular', function(done) {
+        var html = '<div style="width: {{mywidth}}"></div>';
+        var expected = '<div style="width: {{mywidth}}"></div>';
+        test(html, expected, {}, done);
+    });
 });


### PR DESCRIPTION
We could probably get really smart, and "mock" some values, or even "resolve" the promise regardless if postcss failed.

I only made it resolve when we get a synatx error from postcss,  but ideally and with enough consensus we'd want the plugin to resolve irrespective of postcss rejections.

But this PR might kick start some discussions.