### PR TITLE
Fix setting value of `node.content` to be an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(plugins, options) {
                 var styles = indentResolve([].concat(node.content).join(''), indent);
                 promise = css.process(styles, options)
                     .then(function(result) {
-                        node.content = indentResolve(result.css, indent);
+                        node.content = [indentResolve(result.css, indent)];
                     });
 
                 promises.push(promise);


### PR DESCRIPTION
… as other PostHTML plugins will not be expecting a string.

Docs: https://github.com/posthtml/posthtml/blob/master/docs/tree.md