### PR TITLE
Added `filterType` argument

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -20,10 +20,6 @@
     "disallowSpacesInFunctionExpression": {
         "beforeOpeningRoundBrace": true
     },
-    "disallowSpacesInConditionalExpression": {
-        "afterTest": true,
-        "afterConsequent": true
-    },
     "requireSpaceBeforeBlockStatements": 1,
     "requireSpaceAfterKeywords": [
         "do",

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ const postcss = require('posthtml-postcss')
 
 const postcssPlugins = []
 const postcssOptions = {}
+const filterType = /^text\/css$/
 
 const html = readFileSync('./index.html', 'utf8')
 
-posthtml([ postcss(postcssPlugins, postcssOptions) ])
+posthtml([ postcss(postcssPlugins, postcssOptions, filterType) ])
     .process(html)
     .then((result) => console.log(result.html))
 ```
@@ -44,6 +45,7 @@ const postcssPlugins = [
   require('autoprefixer')({ browsers: ['last 2 versions'] })
 ]
 const postcssOptions = {}
+const filterType = /^text\/css$/
 
 const html = `
   <style>div { display: flex; }</style>

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,9 @@ var posthtml = require('posthtml');
 var css = require('..');
 var expect = require('chai').expect;
 
-function test(html, expected, postcssOptions, plugins, done) {
+function test(html, expected, postcssOptions, typeFilter, plugins, done) {
     plugins = plugins || [require('autoprefixer')({ browsers: ['last 2 versions'] })];
-    expect(posthtml([css(plugins, postcssOptions)])
+    expect(posthtml([css(plugins, postcssOptions, typeFilter)])
         .process(html)
         .then(function(result) {
             expect(expected).to.eql(result.html);
@@ -23,49 +23,91 @@ describe('use postcss', function() {
     it('style tag', function(done) {
         var html = '<style>a {display: flex;}</style>';
         var expected = '<style>a {display: -ms-flexbox;display: flex;}</style>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
     });
 
     it('style tag empty', function(done) {
         var html = '<style></style>';
         var expected = '<style></style>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
     });
 
     it('style attrs', function(done) {
         var html = '<div style="display: flex;"></div>';
         var expected = '<div style="display: -ms-flexbox;display: flex;"></div>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
     });
 
     it('style attrs empty', function(done) {
         var html = '<div style></div>';
         var expected = '<div style=""></div>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
     });
 
     it('no style', function(done) {
         var html = 'text <div></div>';
         var expected = 'text <div></div>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
+    });
+
+    it('filtered style tag with standard type', function(done) {
+        var html = '<style type="text/css">a {display: flex;}</style>';
+        var expected = '<style type="text/css">a {display: -ms-flexbox;display: flex;}</style>';
+        test(html, expected, {}, /^text\/css$/, null, done);
+    });
+
+    it('filtered style tag with standard type (with spaces)', function(done) {
+        var html = '<style type=" text/css  ">a {display: flex;}</style>';
+        var expected = '<style type=" text/css  ">a {display: -ms-flexbox;display: flex;}</style>';
+        test(html, expected, {}, /^text\/css$/, null, done);
+    });
+
+    it('filtered style tag with standard type (empty string)', function(done) {
+        var html = '<style type="">a {display: flex;}</style>';
+        var expected = '<style type="">a {display: -ms-flexbox;display: flex;}</style>';
+        test(html, expected, {}, /^text\/css$/, null, done);
+    });
+
+    it('filtered style tag with standard type (one empty space)', function(done) {
+        var html = '<style type=" ">a {display: flex;}</style>';
+        var expected = '<style type=" ">a {display: -ms-flexbox;display: flex;}</style>';
+        test(html, expected, {}, /^text\/css$/, null, done);
+    });
+
+    it('filtered style tag with standard type (two empty spaces)', function(done) {
+        var html = '<style type="  ">a {display: flex;}</style>';
+        var expected = '<style type="  ">a {display: -ms-flexbox;display: flex;}</style>';
+        test(html, expected, {}, /^text\/css$/, null, done);
+    });
+
+    it('filtered style tag with non-standard type', function(done) {
+        var html = '<style type="text/other">a {display: flex;}</style>';
+        var expected = '<style type="text/other">a {display: -ms-flexbox;display: flex;}</style>';
+        test(html, expected, {}, /^text\/other$/, null, done);
+    });
+
+    it('filtered out style tag with non-standard type', function(done) {
+        var html = '<style type="text/other">a {display: flex;}</style>';
+        var expected = html;
+        test(html, expected, {}, /^text\/another$/, null, done);
     });
 
     it('style tag with newline and not indent', function(done) {
         var html = 'text <style>\n.test { color: red; }</style>';
         var expected = 'text <style>\n.test { color: red; }</style>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
     });
 
     it('style tag with newline and multyply indent', function(done) {
         var html = 'text <style>\n    .test {\n    color: red;\n}</style>';
         var expected = 'text <style>\n    .test {\n    color: red;\n}</style>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
     });
 
     it('style tag with newline and indent', function(done) {
         var html = 'text <style>\n    .test { color: red; }</style>';
         var expected = 'text <style>\n    .test { color: red; }</style>';
-        test(html, expected, {}, null, done);
+        test(html, expected, {}, null, null, done);
     });
 
     it('style tag with newline and indent + plugin remove "\\n" character', function(done) {
@@ -78,6 +120,6 @@ describe('use postcss', function() {
             });
         }
 
-        test(html, expected, {}, [plugin], done);
+        test(html, expected, {}, null, [plugin], done);
     });
 });


### PR DESCRIPTION
This PR implements a MIME `filterType` argument to the existing API:
```js
const postcss = require("posthtml-postcss");

posthtml()
.use( postcss(plugins, options, filterType) )
```

Another API design that we could instead choose for this addition is:
```js
posthtml()
.use( postcss(plugins, options).filter(mimeType) )
```

If you prefer that, let me know and I'll change it before you merge.