### PR TITLE
Update dependencies versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "5"
+  - "8"
   - "4"
-  - "0.12"
 
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "posthtml": "^0.10.1"
   },
   "dependencies": {
-    "postcss": "^5.0.12"
+    "postcss": "^6.0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
   },
   "homepage": "https://github.com/posthtml/posthtml-postcss#readme",
   "devDependencies": {
-    "autoprefixer": "^6.1.1",
-    "chai": "^3.3.0",
+    "autoprefixer": "^7.1.6",
+    "chai": "^4.1.2",
     "istanbul": "^0.4.0",
-    "jscs": "^2.3.5",
+    "jscs": "^3.0.7",
     "jshint": "^2.8.0",
-    "mocha": "^2.3.3",
-    "posthtml": "^0.7.0"
+    "mocha": "^4.0.1",
+    "posthtml": "^0.10.1"
   },
   "dependencies": {
     "postcss": "^5.0.12"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": "index.js",
   "scripts": {
     "test": "npm run lint && npm run coverage",
-    "lint": "jshint . && jscs -v .",
+    "lint": "jshint . && jscs .",
     "coverage": "istanbul cover --report text --report html --report lcov node_modules/mocha/bin/_mocha",
     "preversion": "npm test",
     "postversion": "git push && git push --tags && rm -rf coverage"

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var css = require('..');
 var expect = require('chai').expect;
 
 function test(html, expected, postcssOptions, typeFilter, plugins, done) {
-    plugins = plugins || [require('autoprefixer')({ browsers: ['last 2 versions'] })];
+    plugins = plugins || [require('autoprefixer')({ browsers: ['ie >= 10'] })];
     expect(posthtml([css(plugins, postcssOptions, typeFilter)])
         .process(html)
         .then(function(result) {


### PR DESCRIPTION
- jscs@3 not support verbose flag
- in tests use only ie last 2 versions for autoprefixer
- new version of mocha not supports node@0.12 (can it be possible to remove this check from travis?)